### PR TITLE
kinematics.c: implementation for 3 motors

### DIFF
--- a/lib/motor_kinematics.h
+++ b/lib/motor_kinematics.h
@@ -14,8 +14,9 @@ typedef struct {
 } __attribute__((packed)) cmd_set_pwm_t;
 
 #define SET_PWM_ARGS_ERR(cmd_args) \
-        ((cmd_args)->channel > 3) || (fabsf((cmd_args)->pwm_value) < 0.1f) || \
-                                     (fabsf((cmd_args)->pwm_value) > 1.0f)
+        ((cmd_args)->channel > 3) || ((cmd_args)->channel < 1) || \
+        (fabsf((cmd_args)->pwm_value) < 0.1f) || \
+        (fabsf((cmd_args)->pwm_value) > 1.0f)
 
 /*
  * SET_SPEED command args structure
@@ -49,7 +50,7 @@ typedef struct {
         float wz;
         TaskHandle_t mk_notify;
         SemaphoreHandle_t lock;
-        float pwm_motors[4];
+        float pwm_motors[3];
 } motors_ctrl_t;
 
 /*
@@ -67,27 +68,23 @@ StaticSemaphore_t mutex_buffer;
 /*
  * Forward kinematics parameters
  */
-#define MK_MAX_ROT_SPEED 27.22713f
+#define MK_MAX_ROT_SPEED 22.4399f
 #define MK_LIN_KIN_MATRIX \
-        24.4161859f,    27.2213531f,    0.0f, \
-        31.09554175f,  -15.04963672f,   0.0f, \
-        31.07573411f,   16.22788419f,   0.0f, \
-        24.4161859f,   -25.11085301f,   0.0f
+        32.0750f,    -18.5158f,    0.0f, \
+        0.0f,        -37.0370f,    0.0f, \
+        32.0750f,     18.5158f,    0.0f
 
 #define MK_ROT_KIN_MATRIX \
-        0.0f,   0.0f,   -5.77869177f, \
-        0.0f,   0.0f,    4.47936896f, \
-        0.0f,   0.0f,    4.47936896f, \
-        0.0f,   0.0f,   -5.77869177f
+        0.0f,   0.0f,   -6.3671f, \
+        0.0f,   0.0f,    6.3671f,  \
+        0.0f,   0.0f,    6.3671f
 
 #define MK_SPEED2PWM_A \
-        0.0293824f, \
-        0.0293824f, \
-        0.0293824f, \
-        0.0293824f
+        0.03565f, \
+        0.03565f, \
+        0.03565f
 
 #define MK_SPEED2PWM_B \
-        0.1f, \
         0.1f, \
         0.1f, \
         0.1f


### PR DESCRIPTION
1) Change hardware initialization, set pwm and set speed commands
   for 3 motors.
2) Change formard kinematic matrix for 3 motors
3) Correct radians per second to PWM values coefficient taking
   taking into account gear ratios

Signed-off-by: Juan Heredia <juanesheme@gmail.com>